### PR TITLE
første versjon av taksonomi til diskusjon i NAV

### DIFF
--- a/events/navigere/README.md
+++ b/events/navigere/README.md
@@ -1,0 +1,14 @@
+# Navigere
+
+Når en bruker har navigert, for eksempel når de trykker på en lenke.
+
+Denne følger med [dekoratøren](https://github.com/navikt/nav-dekoratoren) så alle klikk i dekoratøren er sporet i alle apper som bruker den.
+
+Team må legge til sporing av navigasjonen i sin egen app som de ønsker. 
+
+Team **bør** legge til disse attributtene for mer verdi i dataene
+
+* destinasjon: target URL brukeren sendes til
+* lenketekst: teksten på lenken som brukeren trykker på
+
+Dette lar teamene se hvor brukeren var og hvor de gikk, og har historikk på hva som stod i lenketeksten. Dette er nyttig når man eksperimenterer med ulike formuleringer for å gjøre det lettere for brukeren å finne frem og forstå innholdet.

--- a/events/navigere/definition.json
+++ b/events/navigere/definition.json
@@ -1,0 +1,7 @@
+{
+    "name": "navigere",
+    "standard": true,
+    "properties": [
+        "url"]
+  }
+  

--- a/events/page_viewed/README.md
+++ b/events/page_viewed/README.md
@@ -1,4 +1,0 @@
-# Page Viewed
-
-Når er bruker kommer på siden og har rukket å sett noe, ca 3 sekunder siden
-doom ready.

--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -1,0 +1,7 @@
+# Sidevisning
+
+Når en bruker har besøkt en side. Inneholder URL brukeren besøkte.
+
+Denne følger med [dekoratøren](https://github.com/navikt/nav-dekoratoren) så team som bruker den trenger ikke logge denne hendelsen i Amplitude eller Google Analytics.
+
+I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med URL brukeren er på når sidevisning logges.

--- a/events/sidevisning/definition.json
+++ b/events/sidevisning/definition.json
@@ -1,5 +1,5 @@
 {
-  "name": "page_viewed",
+  "name": "sidevisning",
   "standard": true,
   "properties": ["url"]
 }


### PR DESCRIPTION
Første versjon av taksonomien til diskusjon i #amplitude i Slack hos NAV.

Stem **opp** om dere er for forslaget og **ned** om dere er imot. **[Diskusjonstråd finner dere her.](https://nav-it.slack.com/archives/CMK1SCBP1/p1599819359040200)**

Jeg har beskrevet 2 event-typer som er gjenbrukbare:

1. - [x] Sidevisning, for å spore hvilke sider en bruker har vært på og føre statistikk om aggregert trafikk og navigasjonsmønster
2. - [x] Navigere, for å spore hvordan brukere navigerer gjennom nettstedet via lenker og andre navigasjonstyper 

Disse bør utviklere gjenbruke i sine applikasjoner for å ha sammenlignbare data på tvers av applikasjoner og for å holde [Amplitude sin maksgrense](https://help.amplitude.com/hc/en-us/articles/115002923888-Limits#h_a1392e14-6dfe-4926-a660-ed81ab30c994) på 2,000 unike event-typer.

