### PR TITLE
Sidevisning forenklet

### DIFF
--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -5,3 +5,10 @@ Når en bruker har besøkt en side. Inneholder URL brukeren besøkte.
 Denne følger med [dekoratøren](https://github.com/navikt/nav-dekoratoren) så team som bruker den trenger ikke logge denne hendelsen i Amplitude eller Google Analytics.
 
 I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med URL brukeren er på når sidevisning logges.
+
+## Attributter
+
+* `platform` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
+* `Status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)
+* `app` Navn på appen
+* `team` Navn på teamet som eier appen

--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -11,6 +11,6 @@ I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med
 * `URL` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
 * `hostname` domenenavn og nivå, for eksempel  `www.nav.no` eller `familie.nav.no`
 * `pagePath` stien på siden, for eksempel `/no/person` 
-* `Status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)
+* `status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)
 * `app` Navn på appen
 * `team` Navn på teamet som eier appen

--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -8,7 +8,7 @@ I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med
 
 ## Attributter
 
-* `URL` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
+* `url` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
 * `hostname` domenenavn og nivå, for eksempel  `www.nav.no` eller `familie.nav.no`
 * `pagePath` stien på siden, for eksempel `/no/person` 
 * `status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)

--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -4,13 +4,8 @@ Når en bruker har besøkt en side. Inneholder URL brukeren besøkte.
 
 Denne følger med [dekoratøren](https://github.com/navikt/nav-dekoratoren) så team som bruker den trenger ikke logge denne hendelsen i Amplitude eller Google Analytics.
 
-I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med URL brukeren er på når sidevisning logges.
+I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes alle events med URL brukeren er på når event logges. Du trenger ikke sende inn URL som et attributt.
 
 ## Attributter
 
-* `url` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
-* `hostname` domenenavn og nivå, for eksempel  `www.nav.no` eller `familie.nav.no`
-* `pagePath` stien på siden, for eksempel `/no/person` 
-* `status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)
-* `app` Navn på appen
-* `team` Navn på teamet som eier appen
+* `status` HTTP status på siden for å se om den finnes (200) eller om brukeren får en feil (404, 500)

--- a/events/sidevisning/README.md
+++ b/events/sidevisning/README.md
@@ -8,7 +8,9 @@ I [Amplitude proxy](https://github.com/navikt/amplitude-proxy) berikes denne med
 
 ## Attributter
 
-* `platform` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
+* `URL` Fullstendig URL på siden uten protokoll, for eksempel `www.nav.no/no/person` uten `https://www.nav.no/no/person`
+* `hostname` domenenavn og nivå, for eksempel  `www.nav.no` eller `familie.nav.no`
+* `pagePath` stien på siden, for eksempel `/no/person` 
 * `Status` HTTP status på siden for å se om den finnes (200), om de besøker via redirect (301, 302) eller får en feil (404, 500)
 * `app` Navn på appen
 * `team` Navn på teamet som eier appen

--- a/events/sidevisning/definition.json
+++ b/events/sidevisning/definition.json
@@ -1,10 +1,10 @@
 {
   "name": "sidevisning",
   "standard": true,
-  "properties": {
-    "platform": window.location.href,
-    "status": "http status",
-    "app": "name of the app",
-    "team": "name of the team who own the app"
-  }
+  "properties": [
+    "platform",
+    "status",
+    "app",
+    "team"
+  ]
 }

--- a/events/sidevisning/definition.json
+++ b/events/sidevisning/definition.json
@@ -2,7 +2,9 @@
   "name": "sidevisning",
   "standard": true,
   "properties": [
-    "platform",
+    "url",
+    "hostname",
+    "pagePath",
     "status",
     "app",
     "team"

--- a/events/sidevisning/definition.json
+++ b/events/sidevisning/definition.json
@@ -1,5 +1,10 @@
 {
   "name": "sidevisning",
   "standard": true,
-  "properties": ["url"]
+  "properties": {
+    "platform": window.location.href,
+    "status": "http status",
+    "app": "name of the app",
+    "team": "name of the team who own the app"
+  }
 }

--- a/events/sidevisning/definition.json
+++ b/events/sidevisning/definition.json
@@ -2,11 +2,6 @@
   "name": "sidevisning",
   "standard": true,
   "properties": [
-    "url",
-    "hostname",
-    "pagePath",
-    "status",
-    "app",
-    "team"
+    "status"
   ]
 }


### PR DESCRIPTION
Endrer **sidevisning** 

Proxyen tar seg av å sende `url`, `hostname` og `pagePath` så team skal slippe det.

Proxyen lager også `app` og `team` om appen er i NAIS så team skal slippe å sende det.

Da gjenstår det å legge til `status` som teamet kan se i enkelte tilfeller. Om vi kan logge 

* 200
* 404 
* 500

Så har vi økt verdien med sidevisning-logging betraktelig og får oversikt på lenkeråte-problemet i historiske data og sanntid