### PR TITLE
Legger til TypeReference som et alternativ til definerte felter som event-properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4504,9 +4504,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
     },
     "union-value": {

--- a/src/generator/generate-function.js
+++ b/src/generator/generate-function.js
@@ -1,4 +1,3 @@
-const ts = require('typescript');
 const factory = require('typescript').factory;
 const printNode = require('./print-node');
 const rewriteName = require('../definitions/rewrite-name');
@@ -46,22 +45,22 @@ function createFunction(eventName) {
             factory.createTypeReferenceNode(
                 factory.createUnionTypeNode([
                   factory.createIdentifier(names.interfaceName),
-                  ts.createTypeLiteralNode([ts.createIndexSignature(
+                  factory.createTypeLiteralNode([factory.createIndexSignature(
                     undefined,
                     undefined,
-                    [ts.createParameter(
+                    [factory.createParameter(
                       undefined,
                       undefined,
                       undefined,
-                      ts.createIdentifier('key'),
+                      factory.createIdentifier('key'),
                       undefined,
-                      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                      factory.createKeywordTypeNode(factory.SyntaxKind.StringKeyword),
                       undefined
                     )],
-                    ts.createUnionTypeNode([
-                      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-                      ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
-                      ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword)
+                    factory.createUnionTypeNode([
+                      factory.createKeywordTypeNode(factory.SyntaxKind.StringKeyword),
+                      factory.createKeywordTypeNode(factory.SyntaxKind.NumberKeyword),
+                      factory.createKeywordTypeNode(factory.SyntaxKind.BooleanKeyword)
                     ])
                   )])
                 ]),

--- a/src/generator/generate-function.js
+++ b/src/generator/generate-function.js
@@ -44,7 +44,27 @@ function createFunction(eventName) {
             factory.createIdentifier('props'),
             undefined,
             factory.createTypeReferenceNode(
-                factory.createIdentifier(names.interfaceName),
+                factory.createUnionTypeNode([
+                  factory.createIdentifier(names.interfaceName),
+                  ts.createTypeLiteralNode([ts.createIndexSignature(
+                    undefined,
+                    undefined,
+                    [ts.createParameter(
+                      undefined,
+                      undefined,
+                      undefined,
+                      ts.createIdentifier('key'),
+                      undefined,
+                      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                      undefined
+                    )],
+                    ts.createUnionTypeNode([
+                      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                      ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+                      ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword)
+                    ])
+                  )])
+                ]),
                 undefined,
             ),
             undefined,

--- a/src/generator/generate-function.js
+++ b/src/generator/generate-function.js
@@ -1,3 +1,4 @@
+const ts = require('typescript');
 const factory = require('typescript').factory;
 const printNode = require('./print-node');
 const rewriteName = require('../definitions/rewrite-name');
@@ -48,19 +49,19 @@ function createFunction(eventName) {
                   factory.createTypeLiteralNode([factory.createIndexSignature(
                     undefined,
                     undefined,
-                    [factory.createParameter(
+                    [ts.createParameter(
                       undefined,
                       undefined,
                       undefined,
                       factory.createIdentifier('key'),
                       undefined,
-                      factory.createKeywordTypeNode(factory.SyntaxKind.StringKeyword),
+                      factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
                       undefined
                     )],
                     factory.createUnionTypeNode([
-                      factory.createKeywordTypeNode(factory.SyntaxKind.StringKeyword),
-                      factory.createKeywordTypeNode(factory.SyntaxKind.NumberKeyword),
-                      factory.createKeywordTypeNode(factory.SyntaxKind.BooleanKeyword)
+                      factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                      factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+                      factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword)
                     ])
                   )])
                 ]),


### PR DESCRIPTION
Events i nåværende kode er smått restriktivt når det kommer til hva brukere får lov til å definere som event-properties. Dersom brukere av biblioteket ønsker å bruke andre properties enn det som er definert, må det forekomme endringer i biblioteket. 
For å gjøre denne biten av koden litt mer relaxed kan en union brukes i typedefinisjonen til parameteret for hver funksjon. Den ene siden peker til interfacet som er definert (slik at kodeforslag fremdeles kan benyttes av IDE), mens den andre siden definerer et objekt med en index signature (som lar brukere definere egne properties om de ønsker det, gitt at de følger de grunnleggende typene som er påkrevd, da).

Resultatet er en generert kode som går fra
```typescript
export function logChatStartet(props: logChatStartetProps): void
```

til 
```typescript
export function logChatStartet(props: logChatStartetProps | {
    [key: string]: string | number | boolean;
}): void
```