### PR TITLE
forslag legg til last_ned som event type i taksonomi

### DIFF
--- a/events/last_ned/README.md
+++ b/events/last_ned/README.md
@@ -1,0 +1,8 @@
+# Last ned
+
+En innbygger laster ned noe. Et dokument fra sin innboks for eksempel, eller en excelfil med statistikk.
+
+| Felt | | Type | Beskrivelse |
+| :--- | :--- | :--- | :--- |
+| type | påkrevd | string | hva slags fil laster man ned? Saksdokument, statistikk |
+| tema | påkrevd | integer | hva handler vedlegget om? Dagpenger, Foreldrepenger |

--- a/events/last_ned/README.md
+++ b/events/last_ned/README.md
@@ -2,8 +2,8 @@
 
 En innbygger laster ned noe. Et dokument fra sin innboks for eksempel, eller en excelfil med statistikk.
 
-| Felt | | Type | Beskrivelse |
+| Felt | Påkrevd eller valgfritt | Type | Beskrivelse |
 | :--- | :--- | :--- | :--- |
 | type | påkrevd | string | hva slags fil laster man ned? Saksdokument, statistikk |
 | tema | påkrevd | string | hva handler vedlegget om? Dagpenger, Foreldrepenger |
-| tittel | påkrevd | string | tittel på dokumentet |
+| tittel | påkrevd | string | tittel på dokumentet som lastes ned |

--- a/events/last_ned/README.md
+++ b/events/last_ned/README.md
@@ -6,3 +6,4 @@ En innbygger laster ned noe. Et dokument fra sin innboks for eksempel, eller en 
 | :--- | :--- | :--- | :--- |
 | type | påkrevd | string | hva slags fil laster man ned? Saksdokument, statistikk |
 | tema | påkrevd | string | hva handler vedlegget om? Dagpenger, Foreldrepenger |
+| tittel | påkrevd | string | tittel på dokumentet |

--- a/events/last_ned/README.md
+++ b/events/last_ned/README.md
@@ -5,4 +5,4 @@ En innbygger laster ned noe. Et dokument fra sin innboks for eksempel, eller en 
 | Felt | | Type | Beskrivelse |
 | :--- | :--- | :--- | :--- |
 | type | påkrevd | string | hva slags fil laster man ned? Saksdokument, statistikk |
-| tema | påkrevd | integer | hva handler vedlegget om? Dagpenger, Foreldrepenger |
+| tema | påkrevd | string | hva handler vedlegget om? Dagpenger, Foreldrepenger |

--- a/events/last_ned/definition.json
+++ b/events/last_ned/definition.json
@@ -3,6 +3,7 @@
     "standard": true,
     "properties": [
       "type",
-      "tema"
+      "tema",
+      "tittel"
     ]
   }  

--- a/events/last_ned/definition.json
+++ b/events/last_ned/definition.json
@@ -1,0 +1,8 @@
+{
+    "name": "last ned",
+    "standard": true,
+    "properties": [
+      "type",
+      "tema"
+    ]
+  }  


### PR DESCRIPTION
Forslag å legge til `last ned` i vår taksonomi for NAV.

Forslaget er fra Dag Helge i Ditt NAV.

Formålet med event-typen er å kunne måle når folk laster ned dokumenter, f.eks fra egen saksoversikt på Ditt NAV, men kan også brukes til å måle når folk laster ned andre vedlegg på nettstedet, f.eks statistikkartikler.

Ønsker en diskusjon om hvilke properties denne event-typen bør inneholde så den er nyttig, kan filtrere til relevante verdier og ikke eksponerer noe identifiserende informasjon om innbyggeren.


| Felt | | Type | Beskrivelse |
| :--- | :--- | :--- | :--- |
| type | påkrevd | string | hva slags fil laster man ned? Saksdokument, statistikk |
| tema | påkrevd | string | hva handler vedlegget om? Dagpenger, Foreldrepenger |