### PR TITLE
legg til accordion i taksonomi

### DIFF
--- a/events/accordion lukket/README.md
+++ b/events/accordion lukket/README.md
@@ -4,4 +4,4 @@ En bruker lukket en accordion
 
 | Felt | | Type | Beskrivelse |
 | :--- | :--- | :--- | :--- |
-| tittel | påkrevd | string | tittel på accordion som lukkes |
+| tekst | påkrevd | string | tekst på accordion som lukkes |

--- a/events/accordion lukket/README.md
+++ b/events/accordion lukket/README.md
@@ -1,0 +1,7 @@
+# Accordion lukket
+
+En bruker lukket en accordion
+
+| Felt | | Type | Beskrivelse |
+| :--- | :--- | :--- | :--- |
+| tittel | påkrevd | string | tittel på accordion som lukkes |

--- a/events/accordion lukket/definition.json
+++ b/events/accordion lukket/definition.json
@@ -2,6 +2,6 @@
     "name": "accordion åpnet",
     "standard": true,
     "properties": [
-      "tittel"
+      "tekst"
     ]
   }  

--- a/events/accordion lukket/definition.json
+++ b/events/accordion lukket/definition.json
@@ -1,0 +1,7 @@
+{
+    "name": "accordion åpnet",
+    "standard": true,
+    "properties": [
+      "tittel"
+    ]
+  }  

--- a/events/accordion åpnet/README.md
+++ b/events/accordion åpnet/README.md
@@ -4,4 +4,4 @@ En bruker åpnet en accordion
 
 | Felt | | Type | Beskrivelse |
 | :--- | :--- | :--- | :--- |
-| tittel | påkrevd | string | tittel på accordion som åpnes |
+| tekst | påkrevd | string | tekst på accordion som åpnes |

--- a/events/accordion åpnet/README.md
+++ b/events/accordion åpnet/README.md
@@ -1,0 +1,7 @@
+# Accordion åpnet
+
+En bruker åpnet en accordion
+
+| Felt | | Type | Beskrivelse |
+| :--- | :--- | :--- | :--- |
+| tittel | påkrevd | string | tittel på accordion som åpnes |

--- a/events/accordion åpnet/definition.json
+++ b/events/accordion åpnet/definition.json
@@ -2,6 +2,6 @@
     "name": "accordion åpnet",
     "standard": true,
     "properties": [
-      "tittel"
+      "tekst"
     ]
   }  

--- a/events/accordion åpnet/definition.json
+++ b/events/accordion åpnet/definition.json
@@ -1,0 +1,7 @@
+{
+    "name": "accordion åpnet",
+    "standard": true,
+    "properties": [
+      "tittel"
+    ]
+  }  


### PR DESCRIPTION
Foreslår at vi legger til accordion i taksonomi

Det er stadig flere team som bruker accordion siden det ble introdusert i design-systemet, og målingene bør følge designsystemet