### PR TITLE
definisjon på filtervalg

### DIFF
--- a/events/filtervalg/README.md
+++ b/events/filtervalg/README.md
@@ -1,0 +1,8 @@
+# Filtervalg
+
+En bruker filtrerer visning av informasjon
+
+| Felt | | Type | Beskrivelse |
+| :--- | :--- | :--- | :--- |
+| kategori | påkrevd | string | tekst på filter som brukes |
+| filternavn | påkrevd | string | tekst på filteralternativet som brukes |

--- a/events/filtervalg/definition.json
+++ b/events/filtervalg/definition.json
@@ -1,0 +1,8 @@
+{
+    "name": "filtervalg",
+    "standard": true,
+    "properties": [
+      "kategori",
+      "filternavn"
+    ]
+  }  


### PR DESCRIPTION
Foreslår at vi legger til taksonomi for bruk av filter, kalt "filtervalg"

Når en innbygger filtrerer for å tilpasse informasjon i en frontend så bør vi logge hvilket filter som brukes og alternativet som filtreres på. 

En bruker kan filtrere på ingen, ett eller en kombinasjon av flere filteralternativ i flere filtermenyer. 

Se eksempel i amplitude for bruk av filter på siden om barnebidrag
https://analytics.eu.amplitude.com/nav/chart/e-m0ouvdn
